### PR TITLE
Fixed CD pipeline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,4 +26,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: latest
+          tags: hiresm/czechitas:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 443
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["AutomatedTestingApp/AutomatedTestingApp/AutomatedTestingApp.csproj", "AutomatedTestingApp/"]
-RUN dotnet restore "AutomatedTestingApp/AutomatedTestingApp/AutomatedTestingApp.csproj"
+RUN dotnet restore "AutomatedTestingApp/AutomatedTestingApp.csproj"
 COPY . .
 WORKDIR "/src/AutomatedTestingApp"
 RUN dotnet build "AutomatedTestingApp.csproj" -c Release -o /app/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY ["AutomatedTestingApp/AutomatedTestingApp/AutomatedTestingApp.csproj", "Aut
 RUN dotnet restore "AutomatedTestingApp/AutomatedTestingApp.csproj"
 COPY . .
 WORKDIR "/src/AutomatedTestingApp"
-RUN dotnet build "AutomatedTestingApp.csproj" -c Release
 
 FROM build AS publish
 RUN dotnet publish "AutomatedTestingApp.csproj" -c Release -o /app/publish /p:UseAppHost=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ["AutomatedTestingApp/AutomatedTestingApp/AutomatedTestingApp.csproj", "Aut
 RUN dotnet restore "AutomatedTestingApp/AutomatedTestingApp.csproj"
 COPY . .
 WORKDIR "/src/AutomatedTestingApp"
-RUN dotnet build "AutomatedTestingApp.csproj" -c Release -o /app/build
+RUN dotnet build "AutomatedTestingApp.csproj" -c Release
 
 FROM build AS publish
 RUN dotnet publish "AutomatedTestingApp.csproj" -c Release -o /app/publish /p:UseAppHost=false


### PR DESCRIPTION
What was done: 
* fixed path in dotnet restore cmd in Dockerfile
* removed unused dotnet build cmd in Dockerfile
* fixed value of tags parameter in docker-image.yml

How to verify:
* docker image is pushed into the[ docker registery](https://hub.docker.com/r/hiresm/czechitas)
* [pipeline is green](https://github.com/czechitas/automated-testing-dotnet-app/actions/runs/6548619748) 

